### PR TITLE
Fix transformation popup

### DIFF
--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -175,7 +175,7 @@ export default function BytecodeDiffView({
       result.push(
         <span
           key={`transformed-${index}`}
-          className={`${colorClasses} cursor-help border rounded-xs hover:brightness-110 transition-all duration-200 relative overflow-x-clip`}
+          className={`${colorClasses} cursor-help rounded-xs hover:brightness-110 transition-all duration-200 relative overflow-x-clip ring-1 ring-inset ring-current`}
           onMouseEnter={() => handleTransformationMouseEnter(transformationInfo)}
           onMouseLeave={handleTransformationMouseLeave}
         >

--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -175,10 +175,17 @@ export default function BytecodeDiffView({
       result.push(
         <span
           key={`transformed-${index}`}
-          className={`${colorClasses} cursor-help border rounded-xs hover:brightness-110 transition-all duration-200`}
+          className={`${colorClasses} cursor-help border rounded-xs hover:brightness-110 transition-all duration-200 relative overflow-x-clip`}
           onMouseEnter={() => handleTransformationMouseEnter(transformationInfo)}
           onMouseLeave={handleTransformationMouseLeave}
         >
+          <span
+            className={`absolute -top-2 text-[7.5px] font-bold ${colorClasses.split(" ")[1]} ${
+              colorClasses.split(" ")[0]
+            } opacity-100 select-none pointer-events-none px-[3px] py-[1px] rounded`}
+          >
+            {transformation.reason}
+          </span>
           {value}
         </span>
       );

--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -216,7 +216,7 @@ export default function BytecodeDiffView({
       {/* Fixed tooltip area as an overlay */}
       {viewMode === "transformations" && (
         <div
-          className={`absolute top-0 left-1/2 transform -translate-x-1/2 z-10 p-3 rounded shadow-md text-xs min-w-[200px] max-w-[80%] transition-all duration-300 ease-in-out ${
+          className={`absolute top-0 left-1/2 transform -translate-x-1/2 z-10 p-3 rounded shadow-md text-xs max-w-[80%] transition-all duration-300 ease-in-out ${
             activeTransformation
               ? "opacity-100 translate-y-0 scale-100"
               : "opacity-0 -translate-y-2 scale-95 pointer-events-none"
@@ -227,24 +227,24 @@ export default function BytecodeDiffView({
           onMouseLeave={handleTooltipMouseLeave}
         >
           {activeTransformation && (
-            <div className="text-xs flex flex-col gap-1 font-sans">
-              <div className="flex gap-1">
-                <span className="font-semibold">Reason:</span>
-                <span className="font-mono ml-1">{activeTransformation.reason}</span>
+            <div className="text-xs flex flex-col gap-2 font-sans w-full">
+              <div className="flex flex-wrap items-baseline">
+                <span className="font-semibold whitespace-nowrap mr-1">Reason:</span>
+                <span className="font-mono overflow-hidden">{activeTransformation.reason}</span>
               </div>
               {activeTransformation.originalValue && (
-                <div className="flex gap-1">
-                  <span className="font-semibold">Original:</span>
-                  <span className="font-mono ml-1 break-all">0x{activeTransformation.originalValue}</span>
+                <div className="flex flex-wrap items-baseline">
+                  <span className="font-semibold whitespace-nowrap mr-1">Original:</span>
+                  <span className="font-mono overflow-hidden break-words">0x{activeTransformation.originalValue}</span>
                 </div>
               )}
-              <div className="flex gap-1">
-                <span className="font-semibold">Transformed:</span>
-                <span className="font-mono ml-1 break-all">0x{activeTransformation.value}</span>
+              <div className="flex flex-wrap items-baseline">
+                <span className="font-semibold whitespace-nowrap mr-1">Transformed:</span>
+                <span className="font-mono overflow-hidden break-words">0x{activeTransformation.value}</span>
               </div>
-              <div className="flex gap-1">
-                <span className="font-semibold">Offset:</span>
-                <span className="font-mono ml-1 break-all">{activeTransformation.offset} bytes</span>
+              <div className="flex flex-wrap items-baseline">
+                <span className="font-semibold whitespace-nowrap mr-1">Offset:</span>
+                <span className="font-mono">{activeTransformation.offset} bytes</span>
               </div>
             </div>
           )}


### PR DESCRIPTION
Fixes https://github.com/ethereum/sourcify/issues/2148

Fixes the transformation tooltip being shifted out of the view. Sets a fixed place for the popup and always show them there. Shows the popup in the matchign color of the transformation e.g. purple for immutables.

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/7545f1a7-d707-4713-8417-67823e64df23" />

Additionally added small labels to show what kind of transformation it is on the highlight:

<img width="91" alt="image" src="https://github.com/user-attachments/assets/157d88aa-73f8-4633-8458-f9422ac3a738" />


Finally I set the border to "inset" so that when going from transformations view to onchain bytecode, the characters won't shift.