### PR TITLE
Fix Transformations label buggy wrapping on Chrome, re-populate the library placeholders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@ethereum-sourcify/bytecode-utils": "^1.3.2",
         "@ethersproject/abi": "^5.8.0",
         "@ethersproject/address": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
         "@monaco-editor/react": "^4.7.0",
         "fuse.js": "^7.1.0",
         "jszip": "^3.10.1",
@@ -18,7 +19,8 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
-        "react-tooltip": "^5.28.0"
+        "react-tooltip": "^5.28.0",
+        "semver": "^7.7.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -27,6 +29,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/semver": "^7.7.0",
         "autoprefixer": "^10.4.16",
         "eslint": "^9",
         "eslint-config-next": "15.2.0",
@@ -280,6 +283,18 @@
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
+      }
+    },
+    "node_modules/@ethereum-sourcify/bytecode-utils/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -1927,6 +1942,13 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.0.tgz",
+      "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.25.0",
@@ -5884,9 +5906,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@ethereum-sourcify/bytecode-utils": "^1.3.2",
     "@ethersproject/abi": "^5.8.0",
     "@ethersproject/address": "^5.8.0",
+    "@ethersproject/keccak256": "^5.8.0",
     "@monaco-editor/react": "^4.7.0",
     "fuse.js": "^7.1.0",
     "jszip": "^3.10.1",
@@ -19,7 +20,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
-    "react-tooltip": "^5.28.0"
+    "react-tooltip": "^5.28.0",
+    "semver": "^7.7.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -28,6 +30,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/semver": "^7.7.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^9",
     "eslint-config-next": "15.2.0",

--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -36,6 +36,9 @@ export default function BytecodeDiffView({
 
   const isOnchainRecompiledSame = onchainBytecode === recompiledBytecode;
 
+  // Check if there are library references in the transformations
+  const hasLibraryReferences = transformations?.some((t) => t.reason === "library");
+
   // Clear any existing close timer when component unmounts
   useEffect(() => {
     return () => {
@@ -331,6 +334,14 @@ export default function BytecodeDiffView({
       <div className="w-full max-h-64 p-3 bg-gray-50 rounded text-xs font-mono border border-gray-200 cursor-text break-words overflow-y-auto whitespace-pre-wrap overflow-x-clip">
         {viewMode === "transformations" ? renderTransformations() : currentView}
       </div>
+
+      {/* Add library placeholder info message */}
+      {viewMode === "recompiled" && hasLibraryReferences && (
+        <div className="mt-2 text-xs text-gray-600 italic border-l-2 border-gray-300 pl-2">
+          Library placeholders are inserted on the frontend, the value in the DB and the API contains `0000`s for
+          placeholders in the bytecode
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -128,7 +128,7 @@ export default function BytecodeDiffView({
       // Add the unchanged part before the transformation
       if (currentIndex < charOffset) {
         result.push(
-          <span key={`unchanged-${id}-${index}`} className="text-gray-800">
+          <span key={`unchanged-${id}-${index}`} className="text-gray-800 break-all">
             {recompiledBytecode.slice(currentIndex, charOffset)}
           </span>
         );
@@ -175,14 +175,14 @@ export default function BytecodeDiffView({
       result.push(
         <span
           key={`transformed-${index}`}
-          className={`${colorClasses} cursor-help rounded-xs hover:brightness-110 transition-all duration-200 relative overflow-x-clip ring-1 ring-inset ring-current`}
+          className={`break-all ${colorClasses} cursor-help rounded-xs hover:brightness-110 transition-all duration-200 relative overflow-x-clip ring-1 ring-inset ring-current`}
           onMouseEnter={() => handleTransformationMouseEnter(transformationInfo)}
           onMouseLeave={handleTransformationMouseLeave}
         >
           <span
             className={`absolute -top-2 text-[7.5px] font-bold ${colorClasses.split(" ")[1]} ${
               colorClasses.split(" ")[0]
-            } opacity-100 select-none pointer-events-none px-[3px] py-[1px] rounded`}
+            } opacity-100 select-none pointer-events-none px-[3px] py-[1px] rounded whitespace-nowrap`}
           >
             {transformation.reason}
           </span>
@@ -328,7 +328,7 @@ export default function BytecodeDiffView({
         </div>
       )}
 
-      <div className="w-full max-h-64 p-3 bg-gray-50 rounded text-xs font-mono border border-gray-200 cursor-text break-words overflow-y-auto whitespace-pre-wrap">
+      <div className="w-full max-h-64 p-3 bg-gray-50 rounded text-xs font-mono border border-gray-200 cursor-text break-words overflow-y-auto whitespace-pre-wrap overflow-x-clip">
         {viewMode === "transformations" ? renderTransformations() : currentView}
       </div>
     </div>

--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -37,7 +37,7 @@ export default function BytecodeDiffView({
   const isOnchainRecompiledSame = onchainBytecode === recompiledBytecode;
 
   // Check if there are library references in the transformations
-  const hasLibraryReferences = transformations?.some((t) => t.reason === "library");
+  const hasLibraryTransformations = transformations?.some((t) => t.reason === "library");
 
   // Clear any existing close timer when component unmounts
   useEffect(() => {
@@ -245,7 +245,11 @@ export default function BytecodeDiffView({
               {activeTransformation.originalValue && (
                 <div className="flex flex-wrap items-baseline">
                   <span className="font-semibold whitespace-nowrap mr-1">Original:</span>
-                  <span className="font-mono overflow-hidden break-words">0x{activeTransformation.originalValue}</span>
+                  <span className="font-mono overflow-hidden break-words">
+                    {/* Don't prefix the __$a2..bc placeholder with 0x */}
+                    {activeTransformation.originalValue.startsWith("__") ? "" : "0x"}
+                    {activeTransformation.originalValue}
+                  </span>
                 </div>
               )}
               <div className="flex flex-wrap items-baseline">
@@ -336,7 +340,7 @@ export default function BytecodeDiffView({
       </div>
 
       {/* Add library placeholder info message */}
-      {viewMode === "recompiled" && hasLibraryReferences && (
+      {viewMode === "recompiled" && hasLibraryTransformations && (
         <div className="mt-2 text-xs text-gray-600 italic border-l-2 border-gray-300 pl-2">
           Library placeholders are inserted on the frontend, the value in the DB and the API contains `0000`s for
           placeholders in the bytecode

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -21,11 +21,21 @@ export interface ContractData {
   address: string;
 }
 
+export interface LibraryReferenceObject {
+  start: number;
+  length: number;
+}
+export interface LinkReferences {
+  [fileName: string]: {
+    [libraryName: string]: LibraryReferenceObject[];
+  };
+}
+
 export interface BytecodeData {
   onchainBytecode: string;
   recompiledBytecode: string;
   sourceMap: string;
-  linkReferences: Record<string, unknown>;
+  linkReferences: LinkReferences;
   cborAuxdata?: Record<
     string,
     {

--- a/src/utils/bytecodeUtils.ts
+++ b/src/utils/bytecodeUtils.ts
@@ -1,0 +1,107 @@
+import { keccak256 } from "@ethersproject/keccak256";
+import { BytecodeData, ContractData } from "@/types/contract";
+import semver from "semver";
+
+/**
+ * Calculates the library placeholder based on the fully qualified name (file:library)
+ * The format differs between Solidity versions pre and post 0.5.0
+ *
+ * @param fqn Fully qualified name of the library (file:library)
+ * @param isPreV050 Whether the contract uses a Solidity version < 0.5.0
+ * @returns The placeholder string that will be in the bytecode
+ */
+export function calculateLibraryPlaceholder(fqn: string, isPreV050: boolean): string {
+  if (isPreV050) {
+    // Pre v0.5.0 format: '__' + fqn.padEnd(38, '_')
+    const trimmedFQN = fqn.slice(0, 36); // in case the fqn is too long
+    return "__" + trimmedFQN.padEnd(38, "_");
+  } else {
+    // Post v0.5.0 format: '__$' + keccak256(fqn).slice(2, 36) + '$__'
+    const hash = keccak256(Buffer.from(fqn)).slice(2, 36);
+    return "__$" + hash + "$__";
+  }
+}
+
+/**
+ * Processes bytecode data to insert library placeholders at the appropriate positions
+ *
+ * @param bytecodeData The bytecode data object containing the original bytecode and link references
+ * @param compilerVersion The Solidity compiler version string
+ * @returns The processed bytecode with library placeholders inserted
+ */
+export function insertLibraryPlaceholders(bytecodeData: BytecodeData, compilerVersion: string): string {
+  if (!bytecodeData.recompiledBytecode || !bytecodeData.linkReferences) {
+    return bytecodeData.recompiledBytecode;
+  }
+
+  // Check if compiler version is pre-0.5.0
+  const isPreV050 = isPreVersion050(compilerVersion);
+
+  let bytecodeWithPlaceholders = bytecodeData.recompiledBytecode;
+  const linkReferences = bytecodeData.linkReferences;
+
+  for (const file in linkReferences) {
+    for (const lib in linkReferences[file]) {
+      const references = linkReferences[file][lib];
+      const fqn = `${file}:${lib}`;
+      const placeholder = calculateLibraryPlaceholder(fqn, isPreV050);
+
+      for (const ref of references) {
+        // Calculate the position in the bytecode string
+        const startPos = ref.start * 2 + 2; // Each byte is 2 hex chars, +2 for "0x" prefix
+        const length = ref.length * 2;
+
+        // Replace the segment with the placeholder
+        bytecodeWithPlaceholders =
+          bytecodeWithPlaceholders.substring(0, startPos) +
+          placeholder +
+          bytecodeWithPlaceholders.substring(startPos + length);
+      }
+    }
+  }
+
+  return bytecodeWithPlaceholders;
+}
+
+/**
+ * Checks if the compiler version is pre-0.5.0
+ * Uses semver for robust version comparison
+ *
+ * @param compilerVersion The compiler version string (e.g., "0.4.24+commit.e67f0147")
+ * @returns True if the version is before 0.5.0, false otherwise
+ */
+function isPreVersion050(compilerVersion: string): boolean {
+  // Normalize version for semver comparison
+  // This handles various formats like "0.4.24+commit.e67f0147"
+  const normalizedVersion = semver.coerce(compilerVersion);
+
+  if (!normalizedVersion) {
+    console.warn(`Failed to parse compiler version: ${compilerVersion}, defaulting to post-0.5.0 format`);
+    return false;
+  }
+
+  // Use semver to compare versions
+  return semver.lt(normalizedVersion, "0.5.0");
+}
+
+/**
+ * Processes both creation and runtime bytecodes, inserting library placeholders
+ *
+ * @param contract The contract object containing creationBytecode, runtimeBytecode and compilation info
+ * @returns An object with processed creation and runtime bytecodes
+ */
+export function processContractBytecodes(contract: ContractData): {
+  processedCreationBytecode: string;
+  processedRuntimeBytecode: string;
+} {
+  const compilerVersion = contract.compilation.compilerVersion;
+
+  const processedCreationBytecode = insertLibraryPlaceholders(contract.creationBytecode, compilerVersion);
+
+  const processedRuntimeBytecode = insertLibraryPlaceholders(contract.runtimeBytecode, compilerVersion);
+
+  return {
+    processedCreationBytecode,
+    processedRuntimeBytecode,
+  };
+}


### PR DESCRIPTION
Fixes the buggy rendering on Chrome, different than Firefox:

<img width="952" alt="Screenshot 2025-05-12 at 18 25 38" src="https://github.com/user-attachments/assets/6f346ecc-0932-4123-8a9c-2db51a9aa5dc" />

to the intended rendering:

<img width="919" alt="image" src="https://github.com/user-attachments/assets/e349d351-32a3-4dfc-ab62-234dfcfb1095" />


In addition adds the library placeholders to the recompiled bytecodes (before they were `0000`s from the DB)

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/ca81b042-e013-4787-aaaa-c29ab436092f" />
