### PR TITLE
Mobile repo.sourcify.dev and Fix: Missing `break-all` 

### DIFF
--- a/src/app/[chainId]/[address]/page.tsx
+++ b/src/app/[chainId]/[address]/page.tsx
@@ -145,10 +145,10 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
     <div>
       <div className="mt-3 mb-2">
         <div className="flex items-center">
-          <h1 className="text-2xl font-bold font-mono text-gray-900">{contract.address}</h1>
-          <CopyToClipboard text={contract.address} className="ml-2" />
+          <h1 className="text-base break-all md:text-2xl font-bold font-mono text-gray-900">{contract.address}</h1>
+          <CopyToClipboard text={contract.address} className="ml-2 md:p-0 p-2" />
         </div>
-        <p className="text-gray-700 mt-1">
+        <p className="text-sm md:text-base text-gray-700 mt-1">
           on {chainName}
           {chains.find((c) => c.chainId.toString() === chainId)?.supported === false && (
             <span className="text-gray-500 text-sm ml-2"> (verification on this chain is deprecated)</span>
@@ -157,16 +157,19 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       </div>
 
       {/* Match status */}
-      <div className="mb-6 flex flex-col gap-1">
-        <div className="flex items-center gap-2">
+      <div className="mb-6">
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Match badge */}
           <span
-            className={`inline-flex items-center px-3 py-1 rounded-md font-semibold border ${matchColor} cursor-help`}
+            className={`inline-flex items-center px-2 py-1 md:px-3 md:py-1 rounded-md font-semibold border ${matchColor} cursor-help text-sm w-auto flex-shrink-0 md:text-base`}
             data-tooltip-id="global-tooltip"
             data-tooltip-content={matchTooltipContent}
           >
-            <span className="mr-1 text-2xl">{matchIcon}</span> {matchLabel}
+            <span className="mr-1 text-xl md:text-2xl">{matchIcon}</span> {matchLabel}
           </span>
-          <div className="flex items-center gap-2 text-sm text-gray-500">
+
+          {/* Bytecode match indicators */}
+          <div className="flex items-center gap-2 md:text-sm text-xs text-gray-500 flex-shrink-0">
             <div className="flex items-center gap-1">
               {contract.runtimeMatch ? (
                 <IoCheckmarkCircle className="text-green-500" />
@@ -204,19 +207,23 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
               </span>
             </div>
           </div>
+
+          {/* Unverified libraries warning */}
           {hasUnverifiedLibraries && (
             <span
-              className="flex items-center gap-1 text-yellow-600 cursor-help"
+              className="flex items-center gap-1 text-yellow-600 cursor-help flex-shrink-0"
               data-tooltip-id="global-tooltip"
               data-tooltip-content="This contract uses unverified libraries. Libraries can contain arbitrary code and should be verified before interacting with the contract."
             >
               <IoWarning className="h-4 w-4" />
-              <span className="text-sm">Unverified Libraries</span>
+              <span className="md:text-sm text-xs">Unverified Libraries</span>
             </span>
           )}
         </div>
+
+        {/* Warning for runtime-only match */}
         {!contract.creationMatch && contract.runtimeMatch && (
-          <div className="mt-2 text-sm text-yellow-600 bg-yellow-50 border border-yellow-200 p-2 rounded">
+          <div className="mt-2 md:text-sm text-xs text-yellow-600 bg-yellow-50 border border-yellow-200 p-2 rounded">
             <div className="flex items-center gap-2">
               <IoWarning className="h-4 w-4 flex-shrink-0" />
               <span>
@@ -252,14 +259,14 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       {/* Contract Source Code Section */}
       <section className="mb-8">
         <div className="sticky top-0 z-10 bg-gray-100 pt-4 pb-2">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between">
             <h2 className="text-xl font-semibold text-gray-800">Source Code</h2>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 text-xs md:text-sm">
               <a
                 href={`https://remix.ethereum.org/?#activate=contract-verification&call=contract-verification//lookupAndSave//sourcify//${contractWithPlaceholders.chainId}//${contractWithPlaceholders.address}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1 text-sm bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200"
+                className="inline-flex items-center gap-1 bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200"
               >
                 <Image
                   src={RemixLogo}
@@ -287,9 +294,9 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       {/* Compiler Settings Section */}
       <section className="mb-8">
         <div className="sticky top-0 z-10 bg-gray-100 py-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between">
             <h2 className="text-xl font-semibold text-gray-800">Compiler Settings</h2>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 text-xs md:text-sm">
               <CopyToClipboardButton data={contractWithPlaceholders.compilation.compilerSettings} />
               <DownloadFileButton
                 data={contractWithPlaceholders.compilation}
@@ -321,7 +328,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       {/* Contract Metadata Section */}
       <section className="mb-8">
         <div className="sticky top-0 z-10 bg-gray-100 py-4">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between">
             <h2 className="text-xl font-semibold text-gray-800">Contract Metadata</h2>
             <div className="flex items-center gap-2">
               <CopyToClipboardButton data={contractWithPlaceholders.metadata} />
@@ -340,7 +347,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       </section>
 
       {/* Creation Bytecode Section */}
-      <section className="mb-8 border border-gray-200 rounded-lg p-6">
+      <section className="mb-8 border border-gray-200 rounded-lg p-3 md:p-6">
         {!contractWithPlaceholders.creationMatch && (
           <div className="mb-4 text-sm text-gray-700 bg-yellow-50 border border-yellow-200 p-3 rounded">
             Contract couldn&apos;t be verified with the creation bytecode but with the runtime bytecode. Below is what
@@ -372,7 +379,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
             contractWithPlaceholders.creationBytecode.transformations.length > 0 && (
               <section className="flex flex-col mt-8 border border-gray-200 rounded-lg p-4 gap-4">
                 <div className="flex items-center gap-2">
-                  <h2 className="text-xl font-semibold text-gray-800">Transformations</h2>
+                  <h2 className="text-lg md:text-xl font-semibold text-gray-800">Transformations</h2>
                   <InfoTooltip
                     content="Transformations are the necessary changes on the non-functional recompiled bytecode sections to achieve the onchain bytecode such as libraries, immutable variables etc. <a href='https://verifieralliance.org/docs/transformations' target='_blank' rel='noopener noreferrer' style='text-decoration: underline;'>Read more</a>"
                     html={true}
@@ -411,9 +418,9 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       </section>
 
       {/* Runtime Bytecode Section */}
-      <section className="mb-8 border border-gray-200 rounded-lg p-6">
+      <section className="mb-8 border border-gray-200 rounded-lg p-3 md:p-6">
         {!contractWithPlaceholders.runtimeMatch && (
-          <div className="mb-4 text-sm text-gray-700 bg-yellow-50 border border-yellow-200 p-3 rounded">
+          <div className="mb-4 text-xs md:text-sm text-gray-700 bg-yellow-50 border border-yellow-200 p-3 rounded">
             Contract couldn&apos;t be verified with the runtime bytecode but with the creation bytecode. Below is what
             was found at the time of verification.
           </div>
@@ -497,7 +504,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       {/* Standard JSON Input Section */}
       <section className="mb-8">
         <div className="sticky top-0 z-10 bg-gray-100 py-4">
-          <div className="flex items-end justify-between">
+          <div className="flex flex-col md:flex-row md:items-end md:justify-between">
             <div>
               <h2 className="text-xl font-semibold text-gray-800">Standard JSON Input</h2>
               <p className="text-gray-700 text-sm">
@@ -523,7 +530,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       {/* Standard JSON Output Section */}
       <section className="mb-8">
         <div className="sticky top-0 z-10 bg-gray-100 py-4">
-          <div className="flex items-end justify-between">
+          <div className="flex flex-col md:flex-row md:items-end md:justify-between">
             <div>
               <h2 className="text-xl font-semibold text-gray-800">Standard JSON Output</h2>
               <p className="text-gray-700 text-sm">

--- a/src/app/[chainId]/[address]/sections/ABI.tsx
+++ b/src/app/[chainId]/[address]/sections/ABI.tsx
@@ -21,7 +21,7 @@ export default function ContractAbi({ abi }: ContractAbiProps) {
   };
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+    <div className="bg-white shadow overflow-auto text-sm md:text-base rounded-lg">
       <div
         className="px-4 py-3 flex justify-between items-center cursor-pointer border-b border-gray-200"
         onClick={() => setSectionExpanded(!sectionExpanded)}

--- a/src/app/[chainId]/[address]/sections/CallProtectionTransformation.tsx
+++ b/src/app/[chainId]/[address]/sections/CallProtectionTransformation.tsx
@@ -18,20 +18,22 @@ export default function CallProtectionTransformation({
 
   return (
     <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-      <h3 className="text-lg font-medium leading-6 text-gray-900 px-6 py-4">Call Protection</h3>
+      <h3 className="text-base md:text-lg font-medium leading-6 text-gray-900 md:px-6 px-3 md:py-4 py-2">
+        Call Protection
+      </h3>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
+        <table className="min-w-full divide-y divide-gray-200 text-[0.65rem] md:text-xs">
           <thead className="bg-gray-50">
             <tr>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 Byte Offset
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 Address
               </th>
@@ -39,8 +41,8 @@ export default function CallProtectionTransformation({
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             <tr>
-              <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">{callProtectionTransformation.offset}</td>
-              <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">
+              <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono">{callProtectionTransformation.offset}</td>
+              <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono">
                 <div className="flex items-center">
                   <span>{transformationValues.callProtection}</span>
                   <CopyToClipboard text={transformationValues.callProtection} className="ml-2" />

--- a/src/app/[chainId]/[address]/sections/CborAuxdataTransformations.tsx
+++ b/src/app/[chainId]/[address]/sections/CborAuxdataTransformations.tsx
@@ -25,32 +25,34 @@ export default function CborAuxdataTransformations({
 
   return (
     <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-      <h3 className="text-lg font-medium leading-6 text-gray-900 px-6 py-4">CBOR Auxdata Transformations</h3>
+      <h3 className="md:text-lg text-base font-medium leading-6 text-gray-900 md:px-6 px-3 md:py-4 py-2">
+        CBOR Auxdata Transformations
+      </h3>
       <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+          <thead className="bg-gray-50 text-[0.65rem] md:text-xs">
             <tr>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 Byte Offsets
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 Length (bytes)
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 Values
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-white divide-y divide-gray-200 text-[0.65rem] md:text-xs">
             {cborTransformations.map((transformation) => {
               const cborAuxdata = transformationValues.cborAuxdata?.[transformation.id] || "";
               // Convert byte offset to character position (each byte is 2 hex chars)
@@ -59,9 +61,9 @@ export default function CborAuxdataTransformations({
 
               return (
                 <tr key={transformation.offset}>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">{transformation.offset}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">{originalValue.length / 2}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">
+                  <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono">{transformation.offset}</td>
+                  <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono">{originalValue.length / 2}</td>
+                  <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono">
                     <div className="flex flex-col gap-0">
                       <div className="flex items-center">
                         <span className="text-gray-500 text-xs w-36 font-sans">Original (recompiled):</span>

--- a/src/app/[chainId]/[address]/sections/ConstructorArguments.tsx
+++ b/src/app/[chainId]/[address]/sections/ConstructorArguments.tsx
@@ -19,8 +19,10 @@ export default function ConstructorArguments({ constructorArguments, abi }: Cons
 
   return (
     <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-      <h3 className="text-lg font-medium leading-6 text-gray-900 px-6 py-4">Constructor Arguments</h3>
-      <div className="px-6 pb-4">
+      <h3 className="md:text-lg text-base font-medium leading-6 text-gray-900 md:px-6 px-3 md:py-4 py-2">
+        Constructor Arguments
+      </h3>
+      <div className="px-3 md:px-6 pb-4">
         <ToggledRawCodeView
           data1={{
             name: "Raw",

--- a/src/app/[chainId]/[address]/sections/ContractDetails.tsx
+++ b/src/app/[chainId]/[address]/sections/ContractDetails.tsx
@@ -55,7 +55,7 @@ export default function ContractDetails({ contract }: ContractDetailsProps) {
   ];
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-lg">
+    <div className="bg-white shadow overflow-auto text-sm md:text-base rounded-lg break-all">
       <div className="border-t border-gray-200">
         <dl>
           {details.map((detail, index) => (

--- a/src/app/[chainId]/[address]/sections/ContractSource.tsx
+++ b/src/app/[chainId]/[address]/sections/ContractSource.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useRef } from "react";
 import Editor from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
 import CopyToClipboardButton from "@/components/CopyToClipboardButton";
+import { useIsMobile } from "@/hooks/useResponsive";
 
 // Define Monaco editor types
 type Monaco = typeof import("monaco-editor");
@@ -291,7 +292,7 @@ export default function ContractSource({ contract }: ContractSourceProps) {
   const monacoRef = useRef<Monaco | null>(null);
 
   const fileNames = Object.keys(contract.sources);
-
+  const isMobile = useIsMobile();
   // Determine language based on file extension
   useEffect(() => {
     if (activeFile) {
@@ -350,9 +351,9 @@ export default function ContractSource({ contract }: ContractSourceProps) {
                   value={contract.sources[activeFile].content}
                   options={{
                     readOnly: true,
-                    minimap: { enabled: true },
+                    minimap: { enabled: isMobile ? false : true },
                     scrollBeyondLastLine: false,
-                    fontSize: 12,
+                    fontSize: isMobile ? 10 : 12,
                     wordWrap: "on",
                     automaticLayout: true,
                     scrollbar: {
@@ -364,7 +365,7 @@ export default function ContractSource({ contract }: ContractSourceProps) {
                       verticalScrollbarSize: 12,
                       horizontalScrollbarSize: 12,
                     },
-                    lineNumbers: "on",
+                    lineNumbers: isMobile ? "off" : "on",
                     glyphMargin: true,
                     folding: true,
                     renderLineHighlight: "all",

--- a/src/app/[chainId]/[address]/sections/ImmutableTransformations.tsx
+++ b/src/app/[chainId]/[address]/sections/ImmutableTransformations.tsx
@@ -28,39 +28,41 @@ export default function ImmutableTransformations({
 
   return (
     <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-      <h3 className="text-lg font-medium leading-6 text-gray-900 px-6 py-4">Immutable Transformations</h3>
+      <h3 className="md:text-lg text-base font-medium leading-6 text-gray-900 md:px-6 px-3 md:py-4 py-2">
+        Immutable Transformations
+      </h3>
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
+        <table className="min-w-full divide-y divide-gray-200 text-[0.65rem] md:text-xs">
           <thead className="bg-gray-50">
             <tr>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 ID
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 Value
               </th>
               <th
                 scope="col"
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                className="px-3 md:px-6 py-3 text-left font-medium text-gray-500 uppercase tracking-wider"
               >
                 Offsets
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-white divide-y divide-gray-200 text-[0.65rem] md:text-xs">
             {Object.entries(groupedTransformations).map(([id, offsets]) => (
               <tr key={id}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">{id}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-500">
+                <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono">{id}</td>
+                <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono text-gray-500">
                   {transformationValues.immutables?.[id] || "N/A"}
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-mono text-gray-500">{offsets.join(", ")}</td>
+                <td className="px-3 md:px-6 py-4 whitespace-nowrap font-mono text-gray-500">{offsets.join(", ")}</td>
               </tr>
             ))}
           </tbody>

--- a/src/app/[chainId]/[address]/sections/LibrariesSection.tsx
+++ b/src/app/[chainId]/[address]/sections/LibrariesSection.tsx
@@ -67,8 +67,8 @@ export default async function LibrariesSection({
   );
 
   return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-lg">
-      <h3 className="text-xl font-medium leading-6 text-gray-900 px-6 py-4">Libraries</h3>
+    <div className="bg-white shadow overflow-hidden rounded-lg">
+      <h3 className="text-xl font-medium leading-6 text-gray-900 md:px-6 md:py-4 px-4 py-4">Libraries</h3>
       {hasUnverifiedLibraries && (
         <div className="px-6 pb-4">
           <div className="bg-yellow-50 border-l-4 border-yellow-400 p-4">
@@ -77,7 +77,7 @@ export default async function LibrariesSection({
                 <IoWarning className="h-5 w-5 text-yellow-400" />
               </div>
               <div className="ml-3">
-                <p className="text-sm text-yellow-700">
+                <p className="md:text-sm text-xs text-yellow-700">
                   This contract uses unverified libraries. Libraries can contain arbitrary code and should be verified
                   before interacting with the contract.
                 </p>
@@ -90,18 +90,18 @@ export default async function LibrariesSection({
         {Object.keys(compilerLinkedLibraries).length > 0 && (
           <div className="px-6 pb-4">
             <h4 className="text-md font-medium text-gray-700 mb-2">Compiler Linked Libraries</h4>
-            <table className="min-w-full divide-y divide-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-xs md:text-sm">
               <thead className="bg-gray-50">
                 <tr>
                   <th
                     scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    className="px-6 py-3 text-left text-xs md:text-sm font-medium text-gray-500 uppercase tracking-wider"
                   >
                     Name
                   </th>
                   <th
                     scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    className="px-6 py-3 text-left text-xs md:text-sm font-medium text-gray-500 uppercase tracking-wider"
                   >
                     Address
                   </th>
@@ -113,7 +113,7 @@ export default async function LibrariesSection({
                   return (
                     <tr key={name}>
                       <td className="px-6 py-4 whitespace-nowrap font-sans">{name}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-mono">
+                      <td className="px-6 py-4 whitespace-nowrap text-xs md:text-sm font-mono">
                         <div className="flex items-center">
                           {isVerified ? (
                             <a

--- a/src/app/[chainId]/[address]/sections/ProxyResolution.tsx
+++ b/src/app/[chainId]/[address]/sections/ProxyResolution.tsx
@@ -80,8 +80,8 @@ export default async function ProxyResolution({ proxyResolution, chainId }: Prox
 
   return (
     <div className="mt-1">
-      <h2 className="text-xl font-semibold text-gray-800">Proxy</h2>
-      <p className="text-gray-500">
+      <h2 className="md:text-xl text-lg font-semibold text-gray-800">Proxy</h2>
+      <p className="text-gray-500 md:text-base text-sm">
         Proxy resolution by{" "}
         <Link
           href="https://github.com/shazow/whatsabi"
@@ -93,7 +93,7 @@ export default async function ProxyResolution({ proxyResolution, chainId }: Prox
         </Link>
       </p>
 
-      <div className="mt-4 bg-white shadow overflow-hidden sm:rounded-lg">
+      <div className="mt-4 bg-white shadow overflow-hidden sm:rounded-lg text-sm md:text-base break-all">
         <div className="border-t border-gray-200">
           <dl>
             <div className="bg-gray-50 px-4 py-3 md:grid md:grid-cols-[150px_1fr] md:gap-4 md:px-6 md:items-center">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,14 +78,14 @@ export default function RootLayout({
           />
         )}
         <header className="shadow-sm">
-          <div className="mx-auto py-4 flex items-center w-full max-w-[100rem] px-8 md:px-12 lg:px-12 xl:px-24">
+          <div className="mx-auto py-4 flex items-center w-full max-w-[100rem] px-6 md:px-12 lg:px-12 xl:px-24">
             <Link href="/" className="flex items-center">
               <Image src="/sourcify.png" alt="Sourcify Logo" className="h-10 w-auto mr-3" width={32} height={32} />
               <span className="text-gray-700 font-vt323 text-2xl">sourcify.eth</span>
             </Link>
           </div>
         </header>
-        <main className="w-full max-w-[100rem] mx-auto px-8 md:px-12 lg:px-12 xl:px-24 py-6 flex-grow">{children}</main>
+        <main className="w-full max-w-[100rem] mx-auto px-6 md:px-12 lg:px-12 xl:px-24 py-6 flex-grow">{children}</main>
         <Footer />
         <AppTooltip />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,10 @@ export default async function Home() {
   const chains = await fetchChains();
   return (
     <div className="w-full mx-auto">
-      <div className="px-4 py-5 sm:p-6 text-center">
-        <h1 className="font-medium text-gray-700 font-vt323 text-5xl mb-8">Sourcify Verified Contract Repository</h1>
+      <div className="md:px-4 py-5 md:p-6 text-center">
+        <h1 className="font-medium text-gray-700 font-vt323 text-3xl md:text-5xl mb-4 md:mb-8">
+          Sourcify Verified Contract Repository
+        </h1>
         <div className="w-full">
           <HomeForm chains={chains} />
         </div>

--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -199,7 +199,7 @@ export default function BytecodeDiffView({
     // Add any remaining unchanged part (except for constructor arguments which are handled above)
     if (currentIndex < onchainBytecode.length) {
       result.push(
-        <span key="remaining" className="text-gray-800">
+        <span key="remaining" className="text-gray-800 break-all">
           {onchainBytecode.slice(currentIndex)}
         </span>
       );

--- a/src/components/BytecodeDiffView.tsx
+++ b/src/components/BytecodeDiffView.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useRef } from "react";
 import InfoTooltip from "./InfoTooltip";
 import { Transformations, TransformationValues } from "@/types/contract";
+import { useIsMobile } from "@/hooks/useResponsive";
 
 interface BytecodeDiffViewProps {
   onchainBytecode: string;
@@ -33,6 +34,9 @@ export default function BytecodeDiffView({
   const [activeTransformation, setActiveTransformation] = useState<TransformationInfo | null>(null);
   const [isTooltipHovered, setIsTooltipHovered] = useState(false);
   const tooltipCloseTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Use the isMobile hook to check screen size
+  const isMobile = useIsMobile();
 
   const isOnchainRecompiledSame = onchainBytecode === recompiledBytecode;
 
@@ -277,7 +281,7 @@ export default function BytecodeDiffView({
         </div>
       )}
       {!isOnchainRecompiledSame && (
-        <div className="flex items-center gap-4 my-2">
+        <div className="flex flex-col md:flex-row md:items-center gap-4 md:my-2 my-2">
           {transformations && transformations.length > 0 && (
             <div className="flex items-center gap-2">
               <input
@@ -335,13 +339,19 @@ export default function BytecodeDiffView({
         </div>
       )}
 
-      <div className="w-full max-h-64 p-3 bg-gray-50 rounded text-xs font-mono border border-gray-200 cursor-text break-words overflow-y-auto whitespace-pre-wrap overflow-x-clip">
+      <div
+        className={`w-full max-h-64 p-3 bg-gray-50 rounded font-mono border border-gray-200 cursor-text break-words overflow-y-auto whitespace-pre-wrap overflow-x-clip ${
+          isMobile ? "text-[0.65rem]" : "text-xs"
+        }`}
+      >
         {viewMode === "transformations" ? renderTransformations() : currentView}
       </div>
 
       {/* Add library placeholder info message */}
       {viewMode === "recompiled" && hasLibraryTransformations && (
-        <div className="mt-2 text-xs text-gray-600 italic border-l-2 border-gray-300 pl-2">
+        <div
+          className={`mt-2 italic border-l-2 border-gray-300 pl-2 text-gray-600 ${isMobile ? "text-[9px]" : "text-xs"}`}
+        >
           Library placeholders are inserted on the frontend, the value in the DB and the API contains `0000`s for
           placeholders in the bytecode
         </div>

--- a/src/components/CodeDisplay.tsx
+++ b/src/components/CodeDisplay.tsx
@@ -6,7 +6,7 @@ interface CodeDisplayProps {
 export default function CodeDisplay({ value, className = "" }: CodeDisplayProps) {
   return (
     <div
-      className={`w-full max-h-64 p-3 bg-gray-50 rounded text-xs font-mono border border-gray-200 cursor-text break-words overflow-y-auto whitespace-pre-wrap ${className}`}
+      className={`w-full max-h-64 p-3 bg-gray-50 rounded text-[0.65rem] md:text-xs font-mono border border-gray-200 cursor-text break-words overflow-y-auto whitespace-pre-wrap ${className}`}
     >
       {value}
     </div>

--- a/src/components/CopyToClipboardButton.tsx
+++ b/src/components/CopyToClipboardButton.tsx
@@ -27,7 +27,7 @@ export default function CopyToClipboardButton({ data, variant = "default" }: Cop
   return (
     <button
       onClick={handleCopy}
-      className={`inline-flex items-center gap-1 text-sm bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200 cursor-pointer relative ${
+      className={`inline-flex items-center gap-1 text-xs md:text-sm bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200 cursor-pointer relative ${
         variant === "icon-only" ? "px-2" : ""
       }`}
       data-tooltip-id="global-tooltip"
@@ -35,12 +35,12 @@ export default function CopyToClipboardButton({ data, variant = "default" }: Cop
     >
       {copied ? (
         <>
-          <FaCheck className="w-4 h-4 text-green-600" />
+          <FaCheck className="h-3 w-3 md:h-4 md:w-4 text-green-600" />
           {variant === "default" && <span className="text-green-600">Copied!</span>}
         </>
       ) : (
         <>
-          <FaRegCopy className="w-4 h-4 text-gray-700" />
+          <FaRegCopy className="h-3 w-3 md:h-4 md:w-4 text-gray-700" />
           {variant === "default" && <span className="text-gray-700">Copy</span>}
         </>
       )}

--- a/src/components/DownloadFileButton.tsx
+++ b/src/components/DownloadFileButton.tsx
@@ -26,9 +26,9 @@ export default function DownloadFileButton({ data, fileName, chainId, address }:
   return (
     <button
       onClick={handleDownload}
-      className="inline-flex items-center gap-1 text-sm bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
+      className="inline-flex items-center gap-1 text-xs md:text-sm bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
     >
-      <FiDownload className="w-4 h-4 text-gray-700" />
+      <FiDownload className="h-3 w-3 md:h-4 md:w-4 text-gray-700" />
       Download
     </button>
   );

--- a/src/components/DownloadSourcesButton.tsx
+++ b/src/components/DownloadSourcesButton.tsx
@@ -33,7 +33,7 @@ export default function DownloadSourcesButton({ sources, chainId, address }: Dow
   return (
     <button
       onClick={handleDownload}
-      className="inline-flex items-center gap-1 text-sm bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
+      className="inline-flex items-center gap-1 text-xs md:text-sm bg-white rounded-md px-2 py-2 shadow-sm border border-gray-200 hover:bg-gray-100 transition-colors duration-200 cursor-pointer"
     >
       <FiDownload className="w-4 h-4 text-gray-700" />
       Download Sources

--- a/src/components/ExampleContracts.tsx
+++ b/src/components/ExampleContracts.tsx
@@ -103,7 +103,7 @@ export default function ExampleContracts({ chains }: ExampleContractsProps) {
                     data-tooltip-content="Verified on Sourcify"
                   />
                 </td>
-                <td className="px-3 py-2 whitespace-nowrap text-sm font-medium text-left">
+                <td className="px-3 py-2 whitespace-nowrap text-sm font-medium text-left max-w-[170px] truncate">
                   <span className="text-blue-600 hover:underline">{contract.name}</span>
                   <div className="text-xs text-gray-500 font-normal">on {getChainName(contract.chainId, chains)}</div>
                 </td>

--- a/src/components/HomeForm.tsx
+++ b/src/components/HomeForm.tsx
@@ -55,7 +55,7 @@ export default function HomeForm({ chains }: HomeFormProps) {
 
   return (
     <>
-      <form className="mt-8 space-y-6 w-full max-w-xl mx-auto mb-10" onSubmit={handleSubmit}>
+      <form className="mt-4 md:mt-8 space-y-6 w-full max-w-xl mx-auto mb-10" onSubmit={handleSubmit}>
         <div className="space-y-4">
           <div>
             <label htmlFor="chainId" className="block text-lg font-medium text-gray-700 mb-1">

--- a/src/components/JsonViewOnlyEditor.tsx
+++ b/src/components/JsonViewOnlyEditor.tsx
@@ -3,6 +3,7 @@
 import { useRef } from "react";
 import Editor from "@monaco-editor/react";
 import type { editor } from "monaco-editor";
+import { useIsMobile } from "@/hooks/useResponsive";
 
 type Monaco = typeof import("monaco-editor");
 
@@ -14,6 +15,9 @@ interface JsonViewOnlyEditorProps {
 export default function JsonViewOnlyEditor({ data, height = "400px" }: JsonViewOnlyEditorProps) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
+
+  // Use isMobile hook to determine font size
+  const isMobile = useIsMobile();
 
   // Format the JSON with indentation for better readability
   const formattedJson = JSON.stringify(data, null, 2);
@@ -32,9 +36,9 @@ export default function JsonViewOnlyEditor({ data, height = "400px" }: JsonViewO
         value={formattedJson}
         options={{
           readOnly: true,
-          minimap: { enabled: true },
+          minimap: { enabled: isMobile ? false : true },
           scrollBeyondLastLine: false,
-          fontSize: 12,
+          fontSize: isMobile ? 10 : 12,
           wordWrap: "on",
           automaticLayout: true,
           scrollbar: {
@@ -52,6 +56,7 @@ export default function JsonViewOnlyEditor({ data, height = "400px" }: JsonViewO
           stickyScroll: {
             enabled: false,
           },
+          lineNumbers: isMobile ? "off" : "on",
         }}
         onMount={handleEditorDidMount}
         theme="vs-dark"

--- a/src/components/ToggledRawCodeView.tsx
+++ b/src/components/ToggledRawCodeView.tsx
@@ -31,7 +31,9 @@ export default function ToggledRawCodeView({ data1, data2, tooltipContent, class
   return (
     <div className={`${className}`}>
       <div className="mb-2 flex items-center">
-        <span className={`mr-2 text-sm ${showFirstOption ? "font-medium" : "text-gray-500"}`}>{data1.name}</span>
+        <span className={`mr-2 text-xs md:text-sm ${showFirstOption ? "font-medium" : "text-gray-500"}`}>
+          {data1.name}
+        </span>
 
         <label className="relative inline-flex items-center cursor-pointer">
           <input
@@ -43,14 +45,16 @@ export default function ToggledRawCodeView({ data1, data2, tooltipContent, class
           <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-gray-300 rounded-full peer peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-gray-900 after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-gray-200"></div>
         </label>
 
-        <span className={`ml-2 text-sm ${!showFirstOption ? "font-medium" : "text-gray-500"}`}>{data2.name}</span>
+        <span className={`ml-2 text-xs md:text-sm ${!showFirstOption ? "font-medium" : "text-gray-500"}`}>
+          {data2.name}
+        </span>
 
         {tooltipContent && <InfoTooltip content={tooltipContent} className="ml-2" />}
       </div>
 
       {!currentData.notBytes && (
         <div className="mb-1 mr-2 flex items-center justify-between">
-          <span className="text-sm text-gray-500">Length: {bytesLength} bytes</span>
+          <span className="text-xs md:text-sm text-gray-500">Length: {bytesLength} bytes</span>
           <CopyToClipboard text={currentData.value} className="ml-2" />
         </div>
       )}

--- a/src/components/TopContracts.tsx
+++ b/src/components/TopContracts.tsx
@@ -192,7 +192,7 @@ export default function TopContracts() {
                       </span>
                     )}
                   </td>
-                  <td className="px-3 py-2 whitespace-nowrap text-sm font-medium text-left">
+                  <td className="px-3 py-2 whitespace-nowrap text-sm font-medium text-left max-w-[170px] truncate">
                     <span className={contract.verified ? "text-blue-600 hover:underline" : "text-gray-600"}>
                       {contract.name || "Unknown"}
                     </span>

--- a/src/components/sections/CborAuxdataSection.tsx
+++ b/src/components/sections/CborAuxdataSection.tsx
@@ -19,16 +19,16 @@ export default function CborAuxdataSection({ cborAuxdata, language }: CborAuxdat
 
   return (
     <div className="mt-6 ml-2">
-      <h3 className="text-xl font-semibold text-gray-800 mt-2">CBOR Auxdata</h3>
-      <p className="text-gray-700 mb-2 text-xs">
+      <h3 className="text-base md:text-lg font-semibold text-gray-800 mt-2">CBOR Auxdata</h3>
+      <p className="text-gray-700 mb-2 text-[0.65rem] md:text-xs">
         These values are what Sourcify extracted from the recompiled bytecode. If these values are different in the
         on-chain bytecode, they will show up in Transformations section.
       </p>
       {Object.entries(cborAuxdata).map(([key, cborAuxdataObj]) => {
         const decodedCborAuxdata = formatCborAuxdata(cborAuxdataObj.value, language);
         return (
-          <div key={key} className="mb-4 rounded-lg border border-gray-200 p-4 ml-4">
-            <h4 className="text-md font-medium">CBOR Auxdata id: {key}</h4>
+          <div key={key} className="mb-4 rounded-lg border border-gray-200 p-2 md:p-4 md:ml-4">
+            <h4 className="md:text-base text-sm font-medium">CBOR Auxdata id: {key}</h4>
             {(decodedCborAuxdata as SolidityDecodedObject)?.ipfs && (
               <div className="my-2">
                 <a
@@ -39,10 +39,10 @@ export default function CborAuxdataSection({ cborAuxdata, language }: CborAuxdat
                 >
                   View on <Image src={ipfsLogo} alt="IPFS Logo" width={36} height={36} />
                 </a>
-                <span className="text-gray-700 ml-2 text-sm">
+                <div className="text-gray-700 mt-2 md:mt-0 md:ml-2 text-xs md:text-sm md:inline">
                   Solidity metadata.json IPFS hash:{" "}
-                  <span className="font-mono">{(decodedCborAuxdata as SolidityDecodedObject).ipfs}</span>
-                </span>
+                  <span className="font-mono break-all">{(decodedCborAuxdata as SolidityDecodedObject).ipfs}</span>
+                </div>
               </div>
             )}
             <Suspense fallback={<LoadingState />}>

--- a/src/hooks/useResponsive.ts
+++ b/src/hooks/useResponsive.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from "react";
+
+// Tailwind's md breakpoint in pixels
+const MD_BREAKPOINT = 768;
+
+/**
+ * Hook that returns screen size information and whether the screen is mobile
+ * @returns Object with width, height, and isMobile
+ */
+export function useScreenSize() {
+  const [screenSize, setScreenSize] = useState({
+    width: typeof window !== "undefined" ? window.innerWidth : 0,
+    height: typeof window !== "undefined" ? window.innerHeight : 0,
+    isMobile: typeof window !== "undefined" ? window.innerWidth < MD_BREAKPOINT : false,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setScreenSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+        isMobile: window.innerWidth < MD_BREAKPOINT,
+      });
+    };
+
+    // Set initial values
+    handleResize();
+
+    // Add event listener
+    window.addEventListener("resize", handleResize);
+
+    // Clean up event listener on unmount
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return screenSize;
+}
+
+/**
+ * Simple hook that returns whether the current screen is mobile (smaller than md breakpoint)
+ * @returns Boolean indicating if the current screen is mobile-sized
+ */
+export function useIsMobile() {
+  const { isMobile } = useScreenSize();
+  return isMobile;
+}


### PR DESCRIPTION
Makes the repo.sourcify.dev mobile friendly

Handles the following case, reason was the `break-all` statement was missing for the last span element.

<img width="831" alt="image" src="https://github.com/user-attachments/assets/f178fd2e-0438-43fd-a051-fcc20b3b4f01" />
