### PR TITLE
Fix empty "evmVersion" case

### DIFF
--- a/src/app/[chainId]/[address]/sections/ContractDetails.tsx
+++ b/src/app/[chainId]/[address]/sections/ContractDetails.tsx
@@ -42,7 +42,10 @@ export default function ContractDetails({ contract }: ContractDetailsProps) {
     { label: "Compilation Target", value: contract.compilation.fullyQualifiedName },
     { label: "Language", value: contract.compilation.language },
     { label: "Compiler", value: `${contract.compilation.compiler} ${contract.compilation.compilerVersion}` },
-    { label: "EVM Version", value: contract.compilation.compilerSettings.evmVersion as string },
+    {
+      label: "EVM Version",
+      value: (contract.compilation.compilerSettings.evmVersion as string | undefined) || "default",
+    },
     { label: "Verified At", value: formatTimestamp(contract.verifiedAt) },
     { label: "Deployer", value: contract.deployment.deployer, copyValue: contract.deployment.deployer },
     {


### PR DESCRIPTION
Turns out the "default" case for evmVersion is actually an empty value, ie. you don't pass the evmVersion in the std-json to the compiler if you want to use the default version. 'default' is not a valid 'evmVersion' value. 

So we need to fill the cases when this is empty when visualizing

E.g.
https://repo.sourcify.dev/56/0xd229ad01d6b0828574226afa1c2837a831984370

<img width="528" height="404" alt="image" src="https://github.com/user-attachments/assets/942c051e-5a2b-4515-845e-88540fbf62d8" />
