### PR TITLE
Fix file path splitting to filter out empty parts

### DIFF
--- a/src/utils/fileExplorer.ts
+++ b/src/utils/fileExplorer.ts
@@ -12,7 +12,7 @@ export function buildFileTreeWithIds(sources: Record<string, SourceData>, fullyQ
   
   // Process each file path
   Object.entries(sources).forEach(([filePath, fileData]) => {
-    const parts = filePath.split('/');
+    const parts = filePath.split('/').filter(part => part !== '');
     let current = root;
     let currentPath = '';
     


### PR DESCRIPTION
Fixes https://github.com/argotorg/sourcify/issues/2554

The contract in the issue has a source which starts with a `/`: 
`/Users/viktor/Documents/POANetwork/test-contract/contracts/Box.sol`