### PR TITLE
feat: add transient storage layout display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 # production
 /build
 
+# claude
+.claude/
+
 # misc
 .DS_Store
 *.pem

--- a/src/app/[chainId]/[address]/page.tsx
+++ b/src/app/[chainId]/[address]/page.tsx
@@ -27,6 +27,7 @@ import CborAuxdataTransformations from "./sections/CborAuxdataTransformations";
 import LibrariesSection from "./sections/LibrariesSection";
 import InfoTooltip from "@/components/InfoTooltip";
 import { processContractBytecodes } from "@/utils/bytecodeUtils";
+import semver from "semver";
 
 // Fetch chains data
 async function getChainsData() {
@@ -129,6 +130,12 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
 
   // Check if there are any unverified libraries
   const hasUnverifiedLibraries = Object.entries(allLibraries).some(([, address]) => !verificationStatus[address]);
+
+  // Check Solidity version for storage layout availability
+  const isSolidity = contract.compilation.language.toLowerCase() === "solidity";
+  const compilerVersion = semver.coerce(contract.compilation.compilerVersion);
+  const hasStorageLayoutSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.5.13");
+  const hasTransientStorageLayoutSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.8.27");
 
   // Determine if this is an exact match
   const isExactMatch = contract.creationMatch === "exact_match" || contract.runtimeMatch === "exact_match";
@@ -551,7 +558,29 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
           <StorageLayout storageLayout={contractWithPlaceholders.storageLayout} />
         ) : (
           <div className="flex flex-col items-center justify-center h-full bg-white rounded-lg p-4">
-            <div className="text-gray-700 text-sm">No storage layouts found in the compiler output.</div>
+            <div className="text-gray-700 text-sm">
+              {!hasStorageLayoutSupport
+                ? "Storage layout is only available for Solidity contracts compiled with version ≥ 0.5.13."
+                : "No storage layouts found in the compiler output."}
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Transient Storage Layout Section */}
+      <section className="mb-8">
+        <div className="sticky top-0 z-10 bg-gray-100 py-4">
+          <h2 className="text-xl font-semibold text-gray-800">Transient Storage Layout</h2>
+        </div>
+        {contractWithPlaceholders.transientStorageLayout?.types ? (
+          <StorageLayout storageLayout={contractWithPlaceholders.transientStorageLayout} />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full bg-white rounded-lg p-4">
+            <div className="text-gray-700 text-sm">
+              {!hasTransientStorageLayoutSupport
+                ? "Transient storage layout is only available for Solidity contracts compiled with version ≥ 0.8.27."
+                : "No transient storage layouts found in the compiler output."}
+            </div>
           </div>
         )}
       </section>

--- a/src/app/[chainId]/[address]/page.tsx
+++ b/src/app/[chainId]/[address]/page.tsx
@@ -136,6 +136,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
   const compilerVersion = semver.coerce(contract.compilation.compilerVersion);
   const hasStorageLayoutSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.5.13");
   const hasTransientStorageLayoutSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.8.27");
+  const hasMetadataSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.4.7");
 
   // Determine if this is an exact match
   const isExactMatch = contract.creationMatch === "exact_match" || contract.runtimeMatch === "exact_match";
@@ -355,11 +356,11 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
       </section>
 
       {/* Contract Metadata Section */}
-      {contractWithPlaceholders.metadata && (
-        <section className="mb-8">
-          <div className="sticky top-0 z-10 bg-gray-100 py-4">
-            <div className="flex flex-col md:flex-row md:items-center md:justify-between">
-              <h2 className="text-xl font-semibold text-gray-800">Contract Metadata</h2>
+      <section className="mb-8">
+        <div className="sticky top-0 z-10 bg-gray-100 py-4">
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+            <h2 className="text-xl font-semibold text-gray-800">Contract Metadata</h2>
+            {contractWithPlaceholders.metadata && (
               <div className="flex items-center gap-2">
                 <CopyToClipboardButton data={contractWithPlaceholders.metadata} />
                 <DownloadFileButton
@@ -369,13 +370,23 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
                   address={contractWithPlaceholders.address}
                 />
               </div>
-            </div>
+            )}
           </div>
+        </div>
+        {contractWithPlaceholders.metadata ? (
           <Suspense fallback={<LoadingState />}>
             <JsonViewOnlyEditor data={contractWithPlaceholders.metadata} />
           </Suspense>
-        </section>
-      )}
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full bg-white rounded-lg p-4">
+            <div className="text-gray-700 text-sm">
+              {!hasMetadataSupport
+                ? "Contract metadata is only available for Solidity contracts compiled with version ≥ 0.4.7."
+                : "No contract metadata found in the compiler output."}
+            </div>
+          </div>
+        )}
+      </section>
 
       {/* Creation Bytecode Section */}
       <section className="mb-8 border border-gray-200 rounded-lg p-3 md:p-6">

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -11,6 +11,7 @@ export interface ContractData {
   abi: AbiItem[] | null;
   metadata: Record<string, unknown> | null;
   storageLayout: StorageLayoutData | null;
+  transientStorageLayout: StorageLayoutData | null;
   userdoc: Record<string, unknown>;
   devdoc: Record<string, unknown>;
   stdJsonInput: Record<string, unknown>;

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -11,7 +11,7 @@ export interface ContractData {
   abi: AbiItem[] | null;
   metadata: Record<string, unknown> | null;
   storageLayout: StorageLayoutData | null;
-  transientStorageLayout: StorageLayoutData | null;
+  transientStorageLayout?: StorageLayoutData | null;
   userdoc: Record<string, unknown>;
   devdoc: Record<string, unknown>;
   stdJsonInput: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Add support for the new `transientStorageLayout` field from the Sourcify API (`fields=all`)
- Reuse the existing `StorageLayout` component to render the transient storage table below the regular storage layout section
- Show version-specific messages when the compiler doesn't support:
  - Contract metadata (Solidity ≥ 0.4.7)
  - Storage layouts (Solidity ≥ 0.5.13)
  - Transient storage layouts (Solidity ≥ 0.8.27)

See https://github.com/argotorg/sourcify/issues/1654
Closes https://github.com/argotorg/sourcify/issues/2596

## Test plan
- [ ] Visit a contract compiled with Solidity ≥ 0.8.27 that uses transient storage (e.g. chain `11155111`, address `0xc5e5ED2d72A0C9E29711C217951F2D595e700a59`) — verify the Transient Storage Layout table renders
- [ ] Visit a contract compiled with Solidity < 0.8.27 — verify the version message is shown for transient storage
- [ ] Visit a contract compiled with Solidity < 0.5.13 — verify the version message is shown for storage layout
- [ ] Visit a contract compiled with Solidity < 0.4.7 — verify the version message is shown for metadata
- [ ] Visit a non-Solidity contract (e.g. Vyper) — verify all three sections show version messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)