### PR TITLE
feat: support Vyper storage layout and overrides

### DIFF
--- a/src/app/[chainId]/[address]/page.tsx
+++ b/src/app/[chainId]/[address]/page.tsx
@@ -567,18 +567,50 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
             </a>
           </div>
         </div>
-        {contractWithPlaceholders.storageLayout?.types ? (
+        {contractWithPlaceholders.storageLayout &&
+        Object.keys(contractWithPlaceholders.storageLayout).length > 0 ? (
           <StorageLayout storageLayout={contractWithPlaceholders.storageLayout} />
         ) : (
           <div className="flex flex-col items-center justify-center h-full bg-white rounded-lg p-4">
             <div className="text-gray-700 text-sm">
-              {!hasStorageLayoutSupport
+              {isSolidity && !hasStorageLayoutSupport
                 ? "Storage layout is only available for Solidity contracts compiled with version ≥ 0.5.13."
                 : "No storage layouts found in the compiler output."}
             </div>
           </div>
         )}
       </section>
+
+      {/* Storage Layout Overrides Section (Vyper) */}
+      {contractWithPlaceholders.additionalInput?.storage_layout_overrides &&
+        Object.keys(contractWithPlaceholders.additionalInput.storage_layout_overrides).length > 0 && (
+          <section className="mb-8">
+            <div className="sticky top-0 z-10 bg-gray-100 py-4">
+              <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+                <h2 className="text-xl font-semibold text-gray-800">Storage Layout Overrides</h2>
+                <div className="flex items-center gap-2 text-xs md:text-sm">
+                  <CopyToClipboardButton
+                    data={contractWithPlaceholders.additionalInput.storage_layout_overrides}
+                  />
+                  <DownloadFileButton
+                    data={contractWithPlaceholders.additionalInput.storage_layout_overrides}
+                    fileName="storage-layout-overrides"
+                    chainId={contractWithPlaceholders.chainId}
+                    address={contractWithPlaceholders.address}
+                  />
+                </div>
+              </div>
+              <p className="text-gray-700 text-sm">
+                Custom storage slot assignments provided as compiler input for this Vyper contract.
+              </p>
+            </div>
+            <Suspense fallback={<LoadingState />}>
+              <JsonViewOnlyEditor
+                data={contractWithPlaceholders.additionalInput.storage_layout_overrides}
+              />
+            </Suspense>
+          </section>
+        )}
 
       {/* Transient Storage Layout Section */}
       <section className="mb-8">

--- a/src/app/[chainId]/[address]/page.tsx
+++ b/src/app/[chainId]/[address]/page.tsx
@@ -134,7 +134,9 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
   // Check Solidity version for storage layout availability
   const isSolidity = contract.compilation.language.toLowerCase() === "solidity";
   const compilerVersion = semver.coerce(contract.compilation.compilerVersion);
+  const isVyper = contract.compilation.language.toLowerCase() === "vyper";
   const hasStorageLayoutSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.5.13");
+  const hasVyperStorageLayoutSupport = isVyper && compilerVersion && semver.gte(compilerVersion, "0.4.1");
   const hasTransientStorageLayoutSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.8.27");
   const hasMetadataSupport = isSolidity && compilerVersion && semver.gte(compilerVersion, "0.4.7");
 
@@ -575,7 +577,9 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
             <div className="text-gray-700 text-sm">
               {isSolidity && !hasStorageLayoutSupport
                 ? "Storage layout is only available for Solidity contracts compiled with version ≥ 0.5.13."
-                : "No storage layouts found in the compiler output."}
+                : isVyper && !hasVyperStorageLayoutSupport
+                  ? "Storage layout is only available for Vyper contracts compiled with version ≥ 0.4.1."
+                  : "No storage layouts found in the compiler output."}
             </div>
           </div>
         )}

--- a/src/app/[chainId]/[address]/sections/StorageLayout.tsx
+++ b/src/app/[chainId]/[address]/sections/StorageLayout.tsx
@@ -1,11 +1,25 @@
-import { StorageLayoutData } from "@/types/contract";
+import {
+  StorageLayoutData,
+  VyperStorageLayout,
+  isSolidityStorageLayout,
+} from "@/types/contract";
 
 interface StorageLayoutProps {
-  storageLayout: StorageLayoutData;
+  storageLayout: StorageLayoutData | VyperStorageLayout;
 }
 
 export default function StorageLayout({ storageLayout }: StorageLayoutProps) {
-  if (!storageLayout || !storageLayout.types) return null;
+  if (!storageLayout) return null;
+
+  if (isSolidityStorageLayout(storageLayout)) {
+    return <SolidityStorageLayout storageLayout={storageLayout} />;
+  }
+
+  return <VyperStorageLayoutTable storageLayout={storageLayout} />;
+}
+
+function SolidityStorageLayout({ storageLayout }: { storageLayout: StorageLayoutData }) {
+  if (!storageLayout.types) return null;
 
   // Function to resolve type name from the types record
   const resolveTypeName = (type: string): string => {
@@ -86,6 +100,67 @@ export default function StorageLayout({ storageLayout }: StorageLayoutProps) {
                   {resolveTypeName(item.type)}
                 </td>
                 <td className="px-6 py-2 whitespace-nowrap text-sm text-gray-500">{item.contract}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function VyperStorageLayoutTable({ storageLayout }: { storageLayout: VyperStorageLayout }) {
+  const entries = Object.entries(storageLayout).sort(([, a], [, b]) => a.slot - b.slot);
+
+  if (entries.length === 0) return null;
+
+  // Track background colors based on slot changes
+  let currentSlot: number | null = null;
+  let isCurrentSlotWhite = true;
+
+  const getBackgroundColor = (slot: number) => {
+    if (slot !== currentSlot) {
+      currentSlot = slot;
+      isCurrentSlotWhite = !isCurrentSlotWhite;
+    }
+    return isCurrentSlotWhite ? "bg-white" : "bg-gray-100";
+  };
+
+  return (
+    <div className="overflow-x-auto rounded-lg shadow-md">
+      <table className="min-w-full divide-y divide-gray-200 border border-gray-200 rounded-lg">
+        <thead className="bg-gray-50">
+          <tr>
+            <th
+              scope="col"
+              className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+            >
+              Slot
+            </th>
+            <th
+              scope="col"
+              className="px-2 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider"
+            >
+              N Slots
+            </th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Variable
+            </th>
+            <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Type
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {entries.map(([name, entry]) => {
+            const bgColor = getBackgroundColor(entry.slot);
+
+            return (
+              <tr key={name} className={bgColor}>
+                <td className="px-2 py-2 text-center whitespace-nowrap text-sm text-gray-500">{entry.slot}</td>
+                <td className="px-2 py-2 text-center whitespace-nowrap text-sm text-gray-500">{entry.n_slots}</td>
+                <td className="px-6 py-2 whitespace-nowrap text-sm text-gray-900">{name}</td>
+                <td className="px-6 py-2 whitespace-nowrap text-sm text-gray-500 font-mono">{entry.type}</td>
               </tr>
             );
           })}

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -10,8 +10,11 @@ export interface ContractData {
   compilation: CompilationData;
   abi: AbiItem[] | null;
   metadata: Record<string, unknown> | null;
-  storageLayout: StorageLayoutData | null;
+  storageLayout: StorageLayoutData | VyperStorageLayout | null;
   transientStorageLayout?: StorageLayoutData | null;
+  additionalInput?: {
+    storage_layout_overrides?: Record<string, VyperStorageLayout>;
+  } | null;
   userdoc: Record<string, unknown>;
   devdoc: Record<string, unknown>;
   stdJsonInput: Record<string, unknown>;
@@ -177,6 +180,20 @@ export interface StorageLayoutData {
     offset: number;
     contract: string;
   }>;
+}
+
+export interface VyperStorageLayoutEntry {
+  type: string;
+  slot: number;
+  n_slots: number;
+}
+
+export type VyperStorageLayout = Record<string, VyperStorageLayoutEntry>;
+
+export function isSolidityStorageLayout(
+  layout: StorageLayoutData | VyperStorageLayout
+): layout is StorageLayoutData {
+  return "storage" in layout && Array.isArray((layout as StorageLayoutData).storage);
 }
 
 export interface SignatureData {


### PR DESCRIPTION
## Summary
- Handle the Vyper storage layout format (`{variableName: {type, slot, n_slots}}`) in addition to the existing Solidity format (`{storage: [...], types: {...}}`)
- Display `storageLayoutOverrides` from `additionalInput` when present for Vyper contracts (as JSON with copy/download)
- Fix empty-state message to only show the Solidity version requirement when the contract is actually Solidity

Addresses: https://github.com/argotorg/sourcify/pull/2739

## Test plan
- [ ] Verify a Solidity contract still renders its storage layout correctly
- [ ] Verify a Vyper contract with storage layout renders the new table (Slot, N Slots, Variable, Type)
- [ ] Verify a Vyper contract with `storage_layout_overrides` in `additionalInput` shows the new "Storage Layout Overrides" section
- [ ] Verify Vyper contracts without storage layout show "No storage layouts found" (not the Solidity version message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)