### PR TITLE
Add staging/dev environment banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,8 +67,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Staging deployments point SOURCIFY_SERVER_URL at the staging server; production uses sourcify.dev.
-  const isStaging = process.env.SOURCIFY_SERVER_URL?.includes("staging") ?? false;
+  // Production deployments set NODE_ENV=production; anything else is treated as staging/dev.
+  const isStaging = process.env.NODE_ENV !== "production";
 
   return (
     <html lang="en" className={``}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -67,15 +67,12 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Production deployments set NODE_ENV=production; anything else is treated as staging/dev.
-  const isStaging = process.env.NODE_ENV !== "production";
-
   return (
     <html lang="en" className={``}>
       <body
         className={`bg-gray-100 min-h-screen flex flex-col font-sans ${ibmPlexSans.variable} ${ibmPlexMono.variable} ${vt323.variable}`}
       >
-        <StagingBanner isStaging={isStaging} />
+        <StagingBanner />
         {process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
           <Script
             src="https://cloud.umami.is/script.js"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import Script from "next/script";
 import "./globals.css";
 import Footer from "@/components/Footer";
 import AppTooltip from "@/components/AppTooltip";
+import StagingBanner from "@/components/StagingBanner";
 import Image from "next/image";
 import Link from "next/link";
 import { FiExternalLink } from "react-icons/fi";
@@ -66,11 +67,15 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Staging deployments point SOURCIFY_SERVER_URL at the staging server; production uses sourcify.dev.
+  const isStaging = process.env.SOURCIFY_SERVER_URL?.includes("staging") ?? false;
+
   return (
     <html lang="en" className={``}>
       <body
         className={`bg-gray-100 min-h-screen flex flex-col font-sans ${ibmPlexSans.variable} ${ibmPlexMono.variable} ${vt323.variable}`}
       >
+        <StagingBanner isStaging={isStaging} />
         {process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
           <Script
             src="https://cloud.umami.is/script.js"

--- a/src/components/StagingBanner.tsx
+++ b/src/components/StagingBanner.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// `isStaging` is determined on the server from SOURCIFY_SERVER_URL (see layout.tsx)
+// since that env var is not exposed to the client.
+export default function StagingBanner({ isStaging }: { isStaging: boolean }) {
+  // Set on the client only to avoid an SSR hydration mismatch.
+  const [url, setUrl] = useState("");
+
+  useEffect(() => {
+    setUrl(window.location.href);
+  }, []);
+
+  if (!isStaging) {
+    return null;
+  }
+
+  return (
+    <div className="w-full bg-cerulean-blue-500 text-white text-center font-medium py-3 px-4">
+      🚧 You are on the <span className="font-bold">staging/dev</span> environment{" "}
+      <span className="mx-1 text-xl align-middle">—</span>{" "}
+      <span className="font-mono font-normal">{url}</span>
+    </div>
+  );
+}

--- a/src/components/StagingBanner.tsx
+++ b/src/components/StagingBanner.tsx
@@ -2,17 +2,23 @@
 
 import { useEffect, useState } from "react";
 
-// `isStaging` is determined on the server from SOURCIFY_SERVER_URL (see layout.tsx)
-// since that env var is not exposed to the client.
-export default function StagingBanner({ isStaging }: { isStaging: boolean }) {
-  // Set on the client only to avoid an SSR hydration mismatch.
-  const [url, setUrl] = useState("");
+// On Netlify this app is SSR'd through functions where NODE_ENV is always
+// "production", so we can't distinguish staging from production via build/runtime
+// env vars. The hostname is the only reliable signal, so detect it on the client:
+// show the banner everywhere except the known production host(s).
+const PRODUCTION_HOSTS = ["repo.sourcify.dev"];
+
+export default function StagingBanner() {
+  // Computed on the client only to avoid an SSR hydration mismatch.
+  const [url, setUrl] = useState<string | null>(null);
+  const [isStaging, setIsStaging] = useState(false);
 
   useEffect(() => {
     setUrl(window.location.href);
+    setIsStaging(!PRODUCTION_HOSTS.includes(window.location.hostname));
   }, []);
 
-  if (!isStaging) {
+  if (!isStaging || url === null) {
     return null;
   }
 


### PR DESCRIPTION
Adds a consistent banner shown only on non-production deployments, matching the ones added to sourcify-ui and verify.sourcify.dev.

## What
- New `StagingBanner` client component rendered at the top of the body in `layout.tsx`.
- Full-width bar in the sourcify blue (`cerulean-blue-500`), white centered text:
  > 🚧 You are on the **staging/dev** environment — `<current URL>`
- Hidden on production.

## Detection
This app is SSR'd through Netlify functions where `NODE_ENV` is always `production`, and this Netlify project's "production branch" is `staging`, so no build/runtime env var (`NODE_ENV`, Netlify `CONTEXT`, etc.) reliably distinguishes staging from production. The only reliable signal is the hostname, so detection is fully client-side: the banner shows on any host except `repo.sourcify.dev` (so it appears on the staging host, Netlify previews, and localhost). Computed in a `useEffect` to avoid a hydration mismatch.

Part of a set of matching banners across sourcify-ui, verify.sourcify.dev, and repo.sourcify.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)