### PR TITLE
fix: avoid stale contract detail cache

### DIFF
--- a/src/app/[chainId]/[address]/page.tsx
+++ b/src/app/[chainId]/[address]/page.tsx
@@ -1,7 +1,7 @@
 import { fetchContractData, fetchChains, getChainName, checkVerification } from "@/utils/api";
 import { Suspense } from "react";
 import { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import LoadingState from "@/components/LoadingState";
 import { IoCheckmarkDoneCircle, IoCheckmarkCircle, IoWarning, IoCloseCircle } from "react-icons/io5";
 import CopyToClipboard from "@/components/CopyToClipboard";
@@ -46,19 +46,21 @@ export async function generateMetadata({
   params: Promise<{ chainId: string; address: string }>;
 }): Promise<Metadata> {
   const { chainId, address } = await params;
+  const normalizedAddress = address.toLowerCase();
 
   // Fetch chains data to get the network name
-  const [chains, contract] = await Promise.all([getChainsData(), getContractData(chainId, address)]);
+  const [chains, contract] = await Promise.all([getChainsData(), getContractData(chainId, normalizedAddress)]);
 
   if (!contract) {
     notFound();
   }
 
   const chainName = getChainName(chainId, chains);
+  const displayAddress = contract.address || normalizedAddress;
 
   return {
-    title: `${address} on ${chainName}`,
-    description: `View contract ${address} on ${chainName} network`,
+    title: `${displayAddress} on ${chainName}`,
+    description: `View contract ${displayAddress} on ${chainName} network`,
     icons: {
       icon: "/favicon-verified.ico",
     },
@@ -67,9 +69,14 @@ export async function generateMetadata({
 
 export default async function ContractPage({ params }: { params: Promise<{ chainId: string; address: string }> }) {
   const { chainId, address } = await params;
+  const normalizedAddress = address.toLowerCase();
+
+  if (address !== normalizedAddress) {
+    redirect(`/${chainId}/${normalizedAddress}`);
+  }
 
   // Fetch data in parallel
-  const [contract, chains] = await Promise.all([getContractData(chainId, address), getChainsData()]);
+  const [contract, chains] = await Promise.all([getContractData(chainId, normalizedAddress), getChainsData()]);
 
   if (!contract) {
     notFound();

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -19,10 +19,11 @@ const revalidateTime = process.env.NODE_ENV === "production" ? 86400 : 3600; // 
  */
 export async function fetchContractData(chainId: string, address: string): Promise<ContractData> {
   const baseUrl = getSourcifyServerUrl();
-  const url = `${baseUrl}/v2/contract/${chainId}/${address}?fields=all`;
+  const normalizedAddress = address.toLowerCase();
+  const url = `${baseUrl}/v2/contract/${chainId}/${normalizedAddress}?fields=all`;
 
   try {
-    const response = await fetch(url, { next: { revalidate: revalidateTime } });
+    const response = await fetch(url, { cache: "no-store" });
 
     if (!response.ok) {
       throw new Error(`Failed to fetch contract data: ${response.status} ${response.statusText}`);
@@ -121,9 +122,10 @@ interface VerificationResponse {
 export async function checkVerification(chainId: string, address: string): Promise<boolean> {
   try {
     const baseUrl = getSourcifyServerUrl();
+    const normalizedAddress = address.toLowerCase();
 
-    const url = `${baseUrl}/v2/contract/${chainId}/${address}`;
-    const response = await fetch(url, { next: { revalidate: revalidateTime } }); // Cache for 1 hour
+    const url = `${baseUrl}/v2/contract/${chainId}/${normalizedAddress}`;
+    const response = await fetch(url, { cache: "no-store" });
 
     // Accept 2xx and 3xx status codes (< 400), but fail on 4xx and 5xx
     if (response.status >= 400) {


### PR DESCRIPTION
## What changed

- Normalize contract addresses to lowercase before fetching contract details or verification status.
- Redirect mixed-case contract detail routes to the lowercase canonical URL.
- Disable Next.js data caching for mutable contract lookup responses.

## Why

Contract verification records can be upgraded after the first lookup. The previous 24h Next data cache keyed entries by the raw URL/address casing, so checksum and lowercase routes could show different creation-match state for the same contract.

## Validation

- `npm run lint`
- `npm run build`

Note: the build still logs existing `SOURCIFY_SERVER_URL is not set` messages while generating growthepie data, but exits successfully.
