### PR TITLE
fix: decode Vyper CBOR auxdata using version-aware style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "contract.sourcify.dev",
       "version": "0.1.0",
       "dependencies": {
-        "@ethereum-sourcify/bytecode-utils": "1.5.2",
+        "@ethereum-sourcify/bytecode-utils": "1.6.0",
         "@ethersproject/abi": "5.8.0",
         "@ethersproject/address": "5.8.0",
         "@ethersproject/keccak256": "5.8.0",
@@ -288,34 +288,22 @@
       }
     },
     "node_modules/@ethereum-sourcify/bytecode-utils": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@ethereum-sourcify/bytecode-utils/-/bytecode-utils-1.5.2.tgz",
-      "integrity": "sha512-4AdOqySymVMks4SmM82bOoKEbMH3H6f2FUP9C3UXiNdwpKZEBD4NEDF0JAM8KtFvSs7KerSHs/kkYWFuQdbUwA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@ethereum-sourcify/bytecode-utils/-/bytecode-utils-1.6.0.tgz",
+      "integrity": "sha512-Q7+MSZZSYKWPhCWw2oX+JHWmaGlOesBU9N9KjfndNiOxbMpw05fx4oF9o0xO9e0VXpyDp95FZHZ917IaRzMcow==",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "5.8.0",
         "base-x": "4.0.1",
         "bs58": "5.0.0",
         "cbor-x": "1.6.4",
-        "semver": "7.7.4"
+        "semver": "7.8.1"
       },
       "engines": {
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"
-      }
-    },
-    "node_modules/@ethereum-sourcify/bytecode-utils/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -1369,9 +1357,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1387,9 +1372,6 @@
       "integrity": "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1407,9 +1389,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1425,9 +1404,6 @@
       "integrity": "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1692,9 +1668,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1712,9 +1685,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1732,9 +1702,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1752,9 +1719,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ethereum-sourcify/bytecode-utils": "1.5.2",
+    "@ethereum-sourcify/bytecode-utils": "1.6.0",
     "@ethersproject/abi": "5.8.0",
     "@ethersproject/address": "5.8.0",
     "@ethersproject/keccak256": "5.8.0",

--- a/src/app/[chainId]/[address]/page.tsx
+++ b/src/app/[chainId]/[address]/page.tsx
@@ -420,6 +420,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
           <CborAuxdataSection
             cborAuxdata={contractWithPlaceholders.creationBytecode.cborAuxdata}
             language={contractWithPlaceholders.compilation.language}
+            compilerVersion={contractWithPlaceholders.compilation.compilerVersion}
           />
 
           {/* Creation Transformations Section */}
@@ -494,6 +495,7 @@ export default async function ContractPage({ params }: { params: Promise<{ chain
           <CborAuxdataSection
             cborAuxdata={contractWithPlaceholders.runtimeBytecode.cborAuxdata}
             language={contractWithPlaceholders.compilation.language}
+            compilerVersion={contractWithPlaceholders.compilation.compilerVersion}
           />
 
           {/* Runtime Transformations Section */}

--- a/src/components/sections/CborAuxdataSection.tsx
+++ b/src/components/sections/CborAuxdataSection.tsx
@@ -10,9 +10,10 @@ import ipfsLogo from "@/assets/ipfs.png";
 interface CborAuxdataSectionProps {
   cborAuxdata: BytecodeData["cborAuxdata"];
   language: string;
+  compilerVersion: string;
 }
 
-export default function CborAuxdataSection({ cborAuxdata, language }: CborAuxdataSectionProps) {
+export default function CborAuxdataSection({ cborAuxdata, language, compilerVersion }: CborAuxdataSectionProps) {
   if (!cborAuxdata || Object.keys(cborAuxdata).length === 0) {
     return null;
   }
@@ -25,7 +26,7 @@ export default function CborAuxdataSection({ cborAuxdata, language }: CborAuxdat
         on-chain bytecode, they will show up in Transformations section.
       </p>
       {Object.entries(cborAuxdata).map(([key, cborAuxdataObj]) => {
-        const decodedCborAuxdata = formatCborAuxdata(cborAuxdataObj.value, language);
+        const decodedCborAuxdata = formatCborAuxdata(cborAuxdataObj.value, language, compilerVersion);
         return (
           <div key={key} className="mb-4 rounded-lg border border-gray-200 p-2 md:p-4 md:ml-4">
             <h4 className="md:text-base text-sm font-medium">CBOR Auxdata id: {key}</h4>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,9 +1,11 @@
-import { decode, AuxdataStyle } from "@ethereum-sourcify/bytecode-utils";
+import { decode, getAuxdataStyle } from "@ethereum-sourcify/bytecode-utils";
 
-export function formatCborAuxdata(rawCborAuxdata: string, language: string) {
+export function formatCborAuxdata(rawCborAuxdata: string, language: string, compilerVersion: string) {
   try {
-    const auxdataStyle =
-      language === "Vyper" ? AuxdataStyle.VYPER : AuxdataStyle.SOLIDITY;
+    // getAuxdataStyle selects the correct decoder style from the language and
+    // compiler version. This matters for Vyper, whose auxdata layout changed
+    // across versions (e.g. < 0.3.10 stores a CBOR map, >= 0.3.10 a CBOR array).
+    const auxdataStyle = getAuxdataStyle(language, compilerVersion);
     const decoded = decode(rawCborAuxdata, auxdataStyle);
     return decoded;
   } catch (error) {


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR depends on a new release of `@ethereum-sourcify/bytecode-utils`.**
> It uses the new `getAuxdataStyle()` helper added in
> [argotorg/sourcify#2830](https://github.com/argotorg/sourcify/pull/2830), which is **merged but not yet published to npm** (latest published is `1.5.3`, which does not export the helper).
>
> **Before this can be merged/deployed:**
> 1. Publish a new `@ethereum-sourcify/bytecode-utils` release that includes #2830.
> 2. Update the dependency version in `package.json` here to match that release (currently set to `1.6.0` as a placeholder) and refresh the lockfile.
>
> Until then CI install will fail because `1.6.0` does not exist on npm yet.

## Problem

On the contract page, CBOR auxdata for **Vyper contracts older than 0.3.10** fails to decode and the UI shows **"Could not decode CBOR auxdata"**.

Example: [`1/0x9e291bfbB158FFaaF1c3A8CcD694BE0d49d6aadA`](https://staging.sourcify.dev) (Vyper `0.3.7`).

## Root cause

`src/utils/format.ts` hardcoded the decoder style:

```ts
const auxdataStyle = language === "Vyper" ? AuxdataStyle.VYPER : AuxdataStyle.SOLIDITY;
```

`AuxdataStyle.VYPER` only describes the layout used by Vyper **>= 0.3.10** (a CBOR array `[runtimesize, datasize, immutablesize, version]`). Older Vyper versions store a CBOR map (`{vyper: [...]}`) with a different length footer, so `decode()` throws `Auxdata is not in the bytecode`.

Verified against the real runtime auxdata `0xa165767970657283000307000b`:

| style | result |
|---|---|
| `VYPER` (current) | ❌ `Auxdata is not in the bytecode` |
| `VYPER_LT_0_3_10` (correct for 0.3.7) | ✅ `{ vyperVersion: "0.3.7" }` |

## Fix

Use the new `getAuxdataStyle(language, compilerVersion)` helper from `bytecode-utils`, which centralizes Vyper's version-dependent auxdata history, and thread `compilerVersion` through to `CborAuxdataSection`.

- `format.ts` — `formatCborAuxdata(value, language, compilerVersion)` → `getAuxdataStyle(...)`
- `CborAuxdataSection.tsx` — accept and forward `compilerVersion`
- `page.tsx` — pass `compilation.compilerVersion` at both (creation + runtime) call sites

## Testing

- `tsc --noEmit` passes (against a local build of bytecode-utils `staging`).
- Decode of the 0.3.7 contract's auxdata now returns `{ vyperVersion: "0.3.7" }`.
- Solidity contracts continue to resolve to `AuxdataStyle.SOLIDITY` (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)