### PR TITLE
security: pin container images to an exact version and digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1
 # Copied from https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
-FROM node:22-alpine AS base
+FROM node:22.23.2-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32 AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
## Summary

Part of the org-wide pinning work (argotorg/sourcify#2919). Pins the container images in this repo to an exact version plus a digest.

Floating tags are mutable two ways: the tag moves on its own as new builds ship, and whoever controls the namespace can repoint it at different content. A digest is the image's content hash, so it can't be repointed.

Changed: `Dockerfile `

## How versions were chosen

- **Node images** stay on the major already in use and move to that major's latest patch — no major upgrades bundled into a security PR.
- **Images previously on `:latest`** are pinned to the version `:latest` resolves to right now, verified by comparing digests, so behaviour is unchanged.
- Digests are the **multi-arch manifest** digest, so arm64 and amd64 both keep resolving.

## Trade-off worth knowing

A pinned digest never updates on its own. That's the point — it's what stops a repointed tag reaching us — but it also means these images stop picking up upstream rebuilds until someone bumps them deliberately. Same policy as argotorg/sourcify#2915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)